### PR TITLE
redirecting mandelweb root URL to application URL

### DIFF
--- a/examples/mandelweb/mandelweb.go
+++ b/examples/mandelweb/mandelweb.go
@@ -17,6 +17,9 @@ import (
 
 func main() {
 	http.HandleFunc("/mandelbrot", mandelbrot)
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/mandelbrot", http.StatusPermanentRedirect)
+	})
 	log.Println("listening on http://127.0.0.1:8080/")
 	http.ListenAndServe(":8080", logRequest(http.DefaultServeMux))
 }


### PR DESCRIPTION
It would be more smooth if I automatically got redirected to the application, during Dave Cheney's talk about Understanding the Go execution tracer in TPE I found myself just coping the console output url leading me to page not found.